### PR TITLE
[#45] 댓글(후기) 관련 api 구현

### DIFF
--- a/athena/src/main/java/goorm/athena/domain/comment/repository/CommentRepository.java
+++ b/athena/src/main/java/goorm/athena/domain/comment/repository/CommentRepository.java
@@ -4,11 +4,14 @@ import goorm.athena.domain.comment.entity.Comment;
 import goorm.athena.domain.project.entity.Project;
 import goorm.athena.domain.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 import java.util.List;
 
 public interface CommentRepository extends JpaRepository<Comment, Long> {
-    List<Comment> findByProject(Project project);
+
+    @Query("SELECT c FROM Comment c JOIN FETCH c.user WHERE c.project = :project")
+    List<Comment> findByProjectWithUser(Project project);
 
     boolean existsByUserAndProject(User user, Project project);
 }

--- a/athena/src/main/java/goorm/athena/domain/comment/service/CommentService.java
+++ b/athena/src/main/java/goorm/athena/domain/comment/service/CommentService.java
@@ -44,7 +44,7 @@ public class CommentService {
     @Transactional(readOnly = true)
     public List<CommentGetResponse> getCommentByProject(Long projectId){
         Project project = projectService.getById(projectId);
-        List<Comment> comments = commentRepository.findByProject(project);
+        List<Comment> comments = commentRepository.findByProjectWithUser(project);
 
         return comments.stream()
                 .map(CommentMapper::toGetResponse)


### PR DESCRIPTION
## Summary

>- close #45 

- 댓글(후기)을 등록, 조회하는 API를 구현했습니다.
- 전체적인 로직은 프로젝트ID에 댓글(후기)을 작성하고, 조회하는 API를 구현했습니다.  
- 검증은 사용자의 중복 댓글 작성에 대한 검증으로 했습니다.
- Swagger에서도 쿠폰 등록, 조회 상태 변경에 맞는 정상적 시나리오가 진행됨을 확인했습니다.

## Tasks
- 댓글(후기)을 등록, 조회하는 API를 구현 완료
- 사용자의 중복 댓글 작성에 대한 검증 완료
- Swagger test 완료

## To Reviewer

### **1. 댓글(후기)는 해당 사용자의 중복 작성에만 검증하도록 했습니다.**
- CommentService에서 유저가 해당 프로젝트의 중복 작성 여부에만 검증하도록 했습니다. 
- 본래 의도는 '후기'이기 때문에 해당 프로젝트를 '주문' = 후원한 적이 있는 경우에만 하려고 했으나 API 연동 시 다음과 같은 과정을 거쳐야 합니다.
![image](https://github.com/user-attachments/assets/48454625-6592-4617-b9d2-dfaf84169a59)

추후, api 연동이 성공적으로 완료된다면 '후기'의 목적에 맞게 검증 절차를 추가하겠습니다
 (예상 구현 방법은 따로 작성해놨습니다)

### 2. n+1 문제를 방지하기 위해 Fetch Join을 사용했습니다.
- 프로젝트의 후기를 조회할 때 후기의 작성자 이름을 가져오는 과정에서 댓글마다 유저의 정보를 호출하여 n+1문제가 발생했습니다.
- FETCH JOIN을 사용하여 연관된 엔티티들을 가져오도록 했습니다.
- 해당 부분은 쿼리 최적화에서 queryDSL을 사용하는 과정에서 같이 리팩토링 할 예정입니다.

## Screenshot