### PR TITLE
[#86] 메인 페이지 프로젝트 조회 응답값 수정 및 조건, 정렬 기준 수정

### DIFF
--- a/athena/src/main/java/goorm/athena/domain/project/dto/res/ProjectTopViewResponse.java
+++ b/athena/src/main/java/goorm/athena/domain/project/dto/res/ProjectTopViewResponse.java
@@ -1,7 +1,6 @@
 package goorm.athena.domain.project.dto.res;
 
 public record ProjectTopViewResponse(
-        Long id,
         String sellerName,
         String title,
         String description,

--- a/athena/src/main/java/goorm/athena/domain/project/mapper/ProjectMapper.java
+++ b/athena/src/main/java/goorm/athena/domain/project/mapper/ProjectMapper.java
@@ -69,7 +69,6 @@ public class ProjectMapper {
     // Entity -> ProjectTopViewResponse(Dto)
     public static ProjectTopViewResponse toTopViewResponse(Project project, String imageUrl){
         return new ProjectTopViewResponse(
-                project.getId(),
                 project.getSeller().getNickname(),
                 project.getTitle(),
                 project.getDescription(),

--- a/athena/src/main/java/goorm/athena/domain/project/repository/ProjectRepository.java
+++ b/athena/src/main/java/goorm/athena/domain/project/repository/ProjectRepository.java
@@ -44,15 +44,12 @@ public interface ProjectRepository extends JpaRepository<Project, Long>, JpaSpec
 
     // queryDSL로 최적화 예정
     @Query(value = """
-                SELECT * FROM (
-                    SELECT p.*,
-                           ROW_NUMBER() OVER (PARTITION BY pp.name ORDER BY p.views DESC, p.created_at ASC) AS rn
-                    FROM project p
-                    JOIN platform_plan pp ON p.platform_plan_id = pp.id
-                    WHERE pp.name IN ('PRO', 'PREMIUM')
-                ) ranked
-                WHERE ranked.rn <= 5
-                """, nativeQuery = true)
+            SELECT p.* 
+            FROM project p
+            JOIN platform_plan pp ON p.platform_plan_id = pp.id
+            WHERE pp.name IN ('PRO', 'PREMIUM')
+            ORDER BY p.created_at DESC
+            """, nativeQuery = true)
     List<Project> findTop5ProjectsGroupedByPlatformPlan();
 
     Page<Project> findByIsApproved(ApprovalStatus isApproved, Pageable pageable);


### PR DESCRIPTION
## Summary

>- close #84 
프로젝트 메인 페이지에서 조회 응답값을 수정하고, 정렬기준을 단순히 최신순 내림차순으로 모두 받아오도록 했습니다.

## Tasks
- 프로젝트 메인페이지 조회 응답값 수정 
- 요금별 프로젝트 조회 정렬 기준을 최신순 내림차순으로 수정

## To Reviewer

## Screenshot