### PR TITLE
[#88] 결제 - 재고 감소 관련 문제 수정 

### DIFF
--- a/athena/src/main/java/goorm/athena/domain/order/service/OrderService.java
+++ b/athena/src/main/java/goorm/athena/domain/order/service/OrderService.java
@@ -68,7 +68,7 @@ public class OrderService {
             if (product.getStock() < item.quantity()) {
                 throw new CustomException(ErrorCode.INSUFFICIENT_INVENTORY);
             }
-            product.decreaseStock(item.quantity());
+//            product.decreaseStock(item.quantity());
 
             OrderItem orderItem = OrderItem.of(order, product, item.quantity());
             totalPrice += orderItem.getPrice();
@@ -84,6 +84,14 @@ public class OrderService {
                 project.getTitle());
 
         return OrderCreateResponse.from(order, orderItems);
+    }
+
+    public void decreaseInventory(Long orderId) {
+        List<OrderItem> orderItems = orderItemRepository.findByOrderId(orderId);
+        for (OrderItem item : orderItems) {
+            Product product = item.getProduct();
+            product.decreaseStock(item.getQuantity());
+        }
     }
 
 }

--- a/athena/src/main/java/goorm/athena/domain/orderitem/repository/OrderItemRepository.java
+++ b/athena/src/main/java/goorm/athena/domain/orderitem/repository/OrderItemRepository.java
@@ -3,6 +3,9 @@ package goorm.athena.domain.orderitem.repository;
 import goorm.athena.domain.orderitem.entity.OrderItem;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface OrderItemRepository extends JpaRepository<OrderItem, Long> {
+    List<OrderItem> findByOrderId(Long orderId);
 
 }

--- a/athena/src/main/java/goorm/athena/domain/payment/service/PaymentService.java
+++ b/athena/src/main/java/goorm/athena/domain/payment/service/PaymentService.java
@@ -2,6 +2,8 @@ package goorm.athena.domain.payment.service;
 
 import goorm.athena.domain.order.entity.Order;
 import goorm.athena.domain.order.service.OrderService;
+import goorm.athena.domain.orderitem.entity.OrderItem;
+import goorm.athena.domain.orderitem.repository.OrderItemRepository;
 import goorm.athena.domain.payment.dto.req.PaymentApproveRequest;
 import goorm.athena.domain.payment.dto.req.PaymentReadyRequest;
 import goorm.athena.domain.payment.dto.res.KakaoPayApproveResponse;
@@ -27,6 +29,7 @@ public class PaymentService {
     private final KakaoPayService kakaoPayService;
     private final OrderService orderService;
     private final PaymentRepository paymentRepository;
+    private final OrderItemRepository orderItemRepository;
 
     public List<Order> getUnsettledOrdersByProjects(List<Project> projects) {
         return paymentRepository.findUnsettledOrdersByProjects(projects);
@@ -82,6 +85,10 @@ public class PaymentService {
 
         payment.approve(pgToken);
 
+        List<OrderItem> orderItems = orderItemRepository.findByOrderId(payment.getOrder().getId());
+        for (OrderItem item : orderItems) {
+            item.getProduct().decreaseStock(item.getQuantity());
+        }
         return response;
     }
 }


### PR DESCRIPTION
## Summary

>- close #88 

결제 도중에 취소를 하는 경우에도 재고가 감소되는 문제 발견 

## Tasks

- 결제 로직에서 카카오 결제 완료가 마무리 되는 경우에만 재고를 감소하도록 로직을 수정 

## To Reviewer


## Screenshot

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Product inventory is now automatically updated to reflect stock reduction immediately after successful payment approval.
- **Improvements**
  - Inventory adjustment is separated from order creation, allowing more precise control over when stock is decremented.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->