### PR TITLE
[#91] 마이페이제 - 배송지 기본 crud추가 

### DIFF
--- a/athena/src/main/java/goorm/athena/domain/deliveryinfo/controller/DeliveryInfoController.java
+++ b/athena/src/main/java/goorm/athena/domain/deliveryinfo/controller/DeliveryInfoController.java
@@ -1,0 +1,59 @@
+package goorm.athena.domain.deliveryinfo.controller;
+
+import goorm.athena.domain.deliveryinfo.dto.req.DeliveryInfoRequest;
+import goorm.athena.domain.deliveryinfo.dto.req.DeliveryInfoUpdateRequest;
+import goorm.athena.domain.deliveryinfo.dto.res.DeliveryInfoResponse;
+import goorm.athena.global.jwt.util.LoginUserRequest;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@Tag(name = "DeliveryInfo", description = "사용자 배송지 관련 API")
+@RequestMapping("/api/delivery")
+public interface DeliveryInfoController {
+
+    @Operation(summary = "배송지 추가 API", description = "입력된 정보로 로그인한 사용자의 배송지를 추가합니다.")
+    @ApiResponse(responseCode = "200", description = "배송지 추가 성공")
+    @PostMapping("/delivery-info")
+    ResponseEntity<Void> addDeliveryInfo(
+            @Parameter(hidden = true) LoginUserRequest loginUser,
+            @RequestBody DeliveryInfoRequest request
+    );
+
+    @Operation(summary = "배송지 수정 API", description = "로그인한 사용자의 기존 배송지 정보를 수정합니다.")
+    @ApiResponse(responseCode = "200", description = "배송지 수정 성공")
+    @PutMapping("/delivery-info/{id}")
+    ResponseEntity<Void> updateDeliveryInfo(
+            @Parameter(hidden = true) LoginUserRequest loginUser,
+            @PathVariable Long id,
+            @RequestBody DeliveryInfoUpdateRequest request
+    );
+
+    @Operation(summary = "배송지 삭제 API", description = "로그인한 사용자의 특정 배송지를 삭제합니다.")
+    @ApiResponse(responseCode = "204", description = "배송지 삭제 성공")
+    @DeleteMapping("/delivery-info/{id}")
+    ResponseEntity<Void> deleteDeliveryInfo(
+            @Parameter(hidden = true) LoginUserRequest loginUser,
+            @PathVariable Long id
+    );
+
+    @Operation(summary = "기본 배송지 설정 API", description = "기존 기본 배송지를 해제하고, 선택한 배송지를 기본 배송지로 설정합니다.")
+    @ApiResponse(responseCode = "200", description = "기본 배송지 설정 성공")
+    @PatchMapping("/delivery-info/{id}/default")
+    ResponseEntity<Void> setDefaultDeliveryInfo(
+            @Parameter(hidden = true) LoginUserRequest loginUser,
+            @PathVariable Long id
+    );
+
+    @Operation(summary = "배송지 목록 조회 API", description = "로그인한 사용자의 배송지 목록을 조회합니다.")
+    @ApiResponse(responseCode = "200", description = "배송지 목록 조회 성공")
+    @GetMapping("/delivery-info")
+    ResponseEntity<List<DeliveryInfoResponse>> getDeliveryInfoList(
+            @Parameter(hidden = true) LoginUserRequest loginUser
+    );
+}

--- a/athena/src/main/java/goorm/athena/domain/deliveryinfo/controller/DeliveryInfoControllerImpl.java
+++ b/athena/src/main/java/goorm/athena/domain/deliveryinfo/controller/DeliveryInfoControllerImpl.java
@@ -1,0 +1,65 @@
+package goorm.athena.domain.deliveryinfo.controller;
+
+import goorm.athena.domain.deliveryinfo.dto.req.DeliveryInfoRequest;
+import goorm.athena.domain.deliveryinfo.dto.req.DeliveryInfoUpdateRequest;
+import goorm.athena.domain.deliveryinfo.dto.res.DeliveryInfoResponse;
+import goorm.athena.domain.deliveryinfo.service.DeliveryInfoService;
+import goorm.athena.global.jwt.util.CheckLogin;
+import goorm.athena.global.jwt.util.LoginUserRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/delivery")
+public class DeliveryInfoControllerImpl  implements DeliveryInfoController {
+
+    private final DeliveryInfoService deliveryInfoService;
+
+    @PostMapping("/delivery-info")
+    public ResponseEntity<Void> addDeliveryInfo(
+            @CheckLogin LoginUserRequest loginUser,
+            @RequestBody DeliveryInfoRequest request
+    ) {
+        deliveryInfoService.addDeliveryInfo(loginUser.userId(), request);
+        return ResponseEntity.ok().build();
+    }
+
+    @PutMapping("/delivery-info/{id}")
+    public ResponseEntity<Void> updateDeliveryInfo(
+            @CheckLogin LoginUserRequest loginUser,
+            @PathVariable Long id,
+            @RequestBody DeliveryInfoUpdateRequest request
+    ) {
+        deliveryInfoService.updateDeliveryInfo(loginUser.userId(), id, request);
+        return ResponseEntity.ok().build();
+    }
+
+    @DeleteMapping("/delivery-info/{id}")
+    public ResponseEntity<Void> deleteDeliveryInfo(
+            @CheckLogin LoginUserRequest loginUser,
+            @PathVariable Long id
+    ) {
+        deliveryInfoService.deleteDeliveryInfo(loginUser.userId(), id);
+        return ResponseEntity.noContent().build();
+    }
+
+    @PatchMapping("/delivery-info/{id}/default")
+    public ResponseEntity<Void> setDefaultDeliveryInfo(
+            @CheckLogin LoginUserRequest loginUser,
+            @PathVariable Long id
+    ) {
+        deliveryInfoService.setDefault(loginUser.userId(), id);
+        return ResponseEntity.ok().build();
+    }
+
+    @GetMapping("/delivery-info")
+    public ResponseEntity<List<DeliveryInfoResponse>> getDeliveryInfoList(
+            @CheckLogin LoginUserRequest loginUser
+    ) {
+        return ResponseEntity.ok(deliveryInfoService.getMyDeliveryInfo(loginUser.userId()));
+    }
+}

--- a/athena/src/main/java/goorm/athena/domain/deliveryinfo/dto/req/DeliveryInfoRequest.java
+++ b/athena/src/main/java/goorm/athena/domain/deliveryinfo/dto/req/DeliveryInfoRequest.java
@@ -1,0 +1,8 @@
+package goorm.athena.domain.deliveryinfo.dto.req;
+
+public record DeliveryInfoRequest(
+     String zipcode,
+     String address,
+     String detailAddress,
+     boolean isDefault
+) {}

--- a/athena/src/main/java/goorm/athena/domain/deliveryinfo/dto/req/DeliveryInfoUpdateRequest.java
+++ b/athena/src/main/java/goorm/athena/domain/deliveryinfo/dto/req/DeliveryInfoUpdateRequest.java
@@ -1,0 +1,7 @@
+package goorm.athena.domain.deliveryinfo.dto.req;
+
+public record DeliveryInfoUpdateRequest(
+        String zipcode,
+        String address,
+        String detailAddress
+) {}

--- a/athena/src/main/java/goorm/athena/domain/deliveryinfo/dto/res/DeliveryInfoResponse.java
+++ b/athena/src/main/java/goorm/athena/domain/deliveryinfo/dto/res/DeliveryInfoResponse.java
@@ -1,0 +1,21 @@
+package goorm.athena.domain.deliveryinfo.dto.res;
+
+import goorm.athena.domain.deliveryinfo.entity.DeliveryInfo;
+
+public record DeliveryInfoResponse(
+        Long id,
+        String zipcode,
+        String address,
+        String detailAddress,
+        boolean isDefault
+) {
+    public static DeliveryInfoResponse from(DeliveryInfo info) {
+        return new DeliveryInfoResponse(
+                info.getId(),
+                info.getZipcode(),
+                info.getAddress(),
+                info.getDetailAddress(),
+                info.isDefault()
+        );
+    }
+}

--- a/athena/src/main/java/goorm/athena/domain/deliveryinfo/entity/DeliveryInfo.java
+++ b/athena/src/main/java/goorm/athena/domain/deliveryinfo/entity/DeliveryInfo.java
@@ -1,8 +1,10 @@
 package goorm.athena.domain.deliveryinfo.entity;
 
 import goorm.athena.domain.user.entity.User;
+import goorm.athena.domain.deliveryinfo.dto.req.DeliveryInfoRequest;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -32,12 +34,39 @@ public class DeliveryInfo {
     @Column(name = "is_default")
     private boolean isDefault = false;
 
+    @Builder
     public DeliveryInfo(User user, String zipcode, String address, String detailAddress, boolean isDefault) {
         this.user = user;
         this.zipcode = zipcode;
         this.address = address;
         this.detailAddress = detailAddress;
         this.isDefault = isDefault;
+    }
+
+    public static DeliveryInfo of(User user, DeliveryInfoRequest request) {
+        return DeliveryInfo.builder()
+                .user(user)
+                .zipcode(request.zipcode())
+                .address(request.address())
+                .detailAddress(request.detailAddress())
+                .isDefault(request.isDefault())
+                .build();
+    }
+
+    public static DeliveryInfo of(User user, DeliveryInfoRequest request, boolean isDefault) {
+        return DeliveryInfo.builder()
+                .user(user)
+                .zipcode(request.zipcode())
+                .address(request.address())
+                .detailAddress(request.detailAddress())
+                .isDefault(isDefault)
+                .build();
+    }
+
+    public void update(String zipcode, String address, String detailAddress) {
+        this.zipcode = zipcode;
+        this.address = address;
+        this.detailAddress = detailAddress;
     }
 
     public void updateDefault(boolean isDefault) {

--- a/athena/src/main/java/goorm/athena/domain/deliveryinfo/repository/DeliveryInfoRepository.java
+++ b/athena/src/main/java/goorm/athena/domain/deliveryinfo/repository/DeliveryInfoRepository.java
@@ -1,13 +1,13 @@
 package goorm.athena.domain.deliveryinfo.repository;
 
 import goorm.athena.domain.deliveryinfo.entity.DeliveryInfo;
+import goorm.athena.domain.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface DeliveryInfoRepository extends JpaRepository<DeliveryInfo, Long> {
     List<DeliveryInfo> findByUserId(Long userId);
-
-    // 기본 배송지 조회
-    DeliveryInfo findByUserIdAndIsDefaultTrue(Long userId);
+    Optional<DeliveryInfo> findByUserIdAndIsDefaultTrue(Long userId);
 }

--- a/athena/src/main/java/goorm/athena/domain/deliveryinfo/service/DeliveryInfoService.java
+++ b/athena/src/main/java/goorm/athena/domain/deliveryinfo/service/DeliveryInfoService.java
@@ -1,20 +1,126 @@
 package goorm.athena.domain.deliveryinfo.service;
 
+import goorm.athena.domain.deliveryinfo.dto.req.DeliveryInfoRequest;
+import goorm.athena.domain.deliveryinfo.dto.req.DeliveryInfoUpdateRequest;
+import goorm.athena.domain.deliveryinfo.dto.res.DeliveryInfoResponse;
 import goorm.athena.domain.deliveryinfo.entity.DeliveryInfo;
 import goorm.athena.domain.deliveryinfo.repository.DeliveryInfoRepository;
+import goorm.athena.domain.user.entity.User;
+import goorm.athena.domain.user.service.UserService;
 import goorm.athena.global.exception.CustomException;
 import goorm.athena.global.exception.ErrorCode;
 import lombok.RequiredArgsConstructor;
+import java.util.stream.Collectors;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+import static java.util.stream.Collectors.toList;
 
 @Service
 @RequiredArgsConstructor
 public class DeliveryInfoService {
 
     private final DeliveryInfoRepository deliveryInfoRepository;
+    private final UserService userService;
 
     public DeliveryInfo getById(Long id) {
         return deliveryInfoRepository.findById(id)
+                .orElseThrow(() -> new CustomException(ErrorCode.DELIVERY_NOT_FOUND));
+    }
+
+    @Transactional
+    public void addDeliveryInfo(Long userId, DeliveryInfoRequest request) {
+        User user = userService.getUser(userId);
+
+        boolean isDefault;
+        try {
+            // 기본 배송지 존재 여부 확인
+            getPrimaryDeliveryInfo(userId);
+            isDefault = request.isDefault();
+            if (isDefault) {
+                unsetPreviousDefault(user); // 기존 기본 해제
+            }
+        } catch (CustomException e) {
+            if (e.getErrorCode() == ErrorCode.DELIVERY_NOT_FOUND) {
+                isDefault = true;
+            } else {
+                throw e;
+            }
+        }
+
+        DeliveryInfo info = DeliveryInfo.of(user, request, isDefault);
+        deliveryInfoRepository.save(info);
+    }
+
+    @Transactional
+    public void updateDeliveryInfo(Long userId, Long id, DeliveryInfoUpdateRequest request) {
+        User user = userService.getUser(userId);
+        DeliveryInfo info = deliveryInfoRepository.findById(id).orElseThrow();
+        if (!info.getUser().getId().equals(user.getId())) {
+            throw new CustomException(ErrorCode.ACCESS_DENIED);
+        }
+        info.update(request.zipcode(), request.address(), request.detailAddress());
+    }
+
+    @Transactional
+    public void deleteDeliveryInfo(Long userId, Long id) {
+        User user = userService.getUser(userId);
+        DeliveryInfo info = deliveryInfoRepository.findById(id)
+                .orElseThrow(() -> new CustomException(ErrorCode.DELIVERY_NOT_FOUND));
+
+        if (!info.getUser().getId().equals(user.getId())) {
+            throw new CustomException(ErrorCode.ACCESS_DENIED);
+        }
+
+        // 기본 배송지면 삭제 제한
+        if (info.isDefault()) {
+            throw new CustomException(ErrorCode.BASIC_ACCOUNT_NOT_DELETED);
+        }
+
+        deliveryInfoRepository.delete(info);
+    }
+
+    @Transactional
+    public void setDefault(Long userId, Long id) {
+        User user = userService.getUser(userId);
+
+        DeliveryInfo newDefault = deliveryInfoRepository.findById(id)
+                .orElseThrow(() -> new CustomException(ErrorCode.DELIVERY_NOT_FOUND));
+
+        if (!newDefault.getUser().getId().equals(user.getId())) {
+            throw new CustomException(ErrorCode.ACCESS_DENIED);
+        }
+
+        if (newDefault.isDefault()) {
+            throw new CustomException(ErrorCode.ALREADY_DEFAULT_DELIVERY);
+        }
+
+        // 현재 기본 배송지가 있다면 false로 변경
+        deliveryInfoRepository.findByUserIdAndIsDefaultTrue(userId)
+                .ifPresent(currentDefault -> currentDefault.updateDefault(false));
+
+        newDefault.updateDefault(true);
+    }
+
+    public List<DeliveryInfoResponse> getMyDeliveryInfo(Long userId) {
+        return deliveryInfoRepository.findByUserId(userId).stream()
+                .map(DeliveryInfoResponse::from)
+                .collect(Collectors.toList());
+    }
+
+    private void unsetPreviousDefault(User user) {
+        List<DeliveryInfo> infos = deliveryInfoRepository.findByUserId(user.getId());
+        for (DeliveryInfo info : infos) {
+            if (info.isDefault()) {
+                info.updateDefault(false);
+            }
+        }
+    }
+
+    public DeliveryInfo getPrimaryDeliveryInfo(Long userId) {
+        return deliveryInfoRepository.findByUserIdAndIsDefaultTrue(userId)
                 .orElseThrow(() -> new CustomException(ErrorCode.DELIVERY_NOT_FOUND));
     }
 }

--- a/athena/src/main/java/goorm/athena/global/exception/ErrorCode.java
+++ b/athena/src/main/java/goorm/athena/global/exception/ErrorCode.java
@@ -72,7 +72,10 @@ public enum ErrorCode {
     SAME_ACCOUNT_STATUS(HttpStatus.CONFLICT, "요청한 계좌가 변경할 계좌와 일치합니다."),
     INACCURATE_BANK_ACCOUNT(HttpStatus.BAD_REQUEST, "사용자가 등록한 계좌 정보가 아닙니다."),
     BASIC_ACCOUNT_NOT_DELETED(HttpStatus.CONFLICT, "기본 계좌는 삭제할 수 없습니다."),
-    BANK_ACCOUNT_NOT_FOUND(HttpStatus.NOT_FOUND, "사용자 은행 계좌를 찾을 수 없습니다.");
+    BANK_ACCOUNT_NOT_FOUND(HttpStatus.NOT_FOUND, "사용자 은행 계좌를 찾을 수 없습니다."),
+
+    // 배송지
+    ALREADY_DEFAULT_DELIVERY(HttpStatus.CONFLICT, "이미 기본 배송지로 설정되어 있습니다.");
 
     private final HttpStatus errorCode;
     private final String errorMessage;


### PR DESCRIPTION
## Summary

>- close #91 
마이페이지에 사용되는 배송지 관련crud를 추가했습니다 

## Tasks
- 배송지 추가,삭제,(기본배송지 설정)수정, 목록 api 구현 

## To Reviewer

- 배송지 추가 경우 처음 생성하는 경우 기본배송지로 자동설정하게 되어있습니다 
- 배송지 삭제 경우 기본 배송지 인경우 삭제가 안되게 했습니다 
- 기본 배송지 수정 경우 이미 기본배송지인 경우 수정이 안되게 헀습니다 

## Screenshot