### PR TITLE
[#103] 더미데이터 api 추가 + 쿼리 출력 커스텀 

### DIFF
--- a/athena/build.gradle
+++ b/athena/build.gradle
@@ -24,6 +24,7 @@ repositories {
 }
 
 dependencies {
+
 	implementation 'org.springframework.boot:spring-boot-starter-security'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
@@ -51,6 +52,15 @@ dependencies {
 	annotationProcessor 'com.querydsl:querydsl-apt:5.0.0:jakarta'
 	annotationProcessor 'jakarta.annotation:jakarta.annotation-api'
 	annotationProcessor 'jakarta.persistence:jakarta.persistence-api'
+
+	// dummy
+	implementation 'net.datafaker:datafaker:2.0.1'
+	implementation 'org.springframework.boot:spring-boot-starter-jdbc'
+
+	// log
+	implementation 'com.github.gavlyukovskiy:p6spy-spring-boot-starter:1.9.0'
+
+
 }
 
 tasks.named('test') {

--- a/athena/src/main/java/goorm/athena/domain/dummy/controller/DummyController.java
+++ b/athena/src/main/java/goorm/athena/domain/dummy/controller/DummyController.java
@@ -1,0 +1,15 @@
+package goorm.athena.domain.dummy.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+
+@Tag(name = "~ 더미 데이터", description = "더미 유저 생성 API")
+public interface DummyController {
+
+    @Operation(summary = "더미 유저 생성", description = "입력된 숫자만큼 유저/계좌/배송지 더미 데이터를 생성합니다.")
+    @PostMapping("/api/dev/dummy-users")
+    ResponseEntity<String> createDummyUsers(@RequestParam(defaultValue = "10") int count);
+}

--- a/athena/src/main/java/goorm/athena/domain/dummy/controller/DummyControllerImpl.java
+++ b/athena/src/main/java/goorm/athena/domain/dummy/controller/DummyControllerImpl.java
@@ -1,0 +1,23 @@
+package goorm.athena.domain.dummy.controller;
+
+import goorm.athena.domain.dummy.service.DummyService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/dev")
+public class DummyControllerImpl implements DummyController {
+
+    private final DummyService dummyDataService;
+
+    @PostMapping("/dummy-users")
+    public ResponseEntity<String> createDummyUsers(@RequestParam(defaultValue = "10") int count) {
+        dummyDataService.generateDummyUsers(count);
+        return ResponseEntity.ok(count + "개의 더미 유저가 생성되었습니다.");
+    }
+}

--- a/athena/src/main/java/goorm/athena/domain/dummy/service/DummyService.java
+++ b/athena/src/main/java/goorm/athena/domain/dummy/service/DummyService.java
@@ -1,0 +1,187 @@
+package goorm.athena.domain.dummy.service;
+
+import goorm.athena.domain.project.entity.PlanName;
+import goorm.athena.domain.project.entity.PlatformPlan;
+import goorm.athena.domain.project.repository.PlatformPlanRepository;
+import goorm.athena.domain.user.entity.Role;
+import lombok.RequiredArgsConstructor;
+import net.datafaker.Faker;
+import org.springframework.jdbc.core.BatchPreparedStatementSetter;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.sql.PreparedStatement;
+import java.util.*;
+
+@Service
+@RequiredArgsConstructor
+public class DummyService {
+
+    private final JdbcTemplate jdbcTemplate;
+    private final PlatformPlanRepository platformPlanRepository;
+
+    private final Faker fakerKo = new Faker(new Locale("ko"));
+    private final Faker fakerEn = new Faker(Locale.ENGLISH);
+
+    @Transactional
+    public void generateDummyUsers(int count) {
+        insertPlatformPlansIfNotExists();
+
+        boolean adminExists = checkAdminExists();
+        int actualCount = adminExists ? count : count - 1;
+
+        List<UserInfo> users = new ArrayList<>();
+
+        if (!adminExists) {
+            users.add(generateUserInfo("admin@admin.com", "admin", "admin", Role.ROLE_ADMIN));
+        }
+
+        for (int i = 0; i < actualCount; i++) {
+            String email = generateEmail();
+            String password = "123";
+            String nickname = fakerKo.name().lastName() + fakerKo.name().firstName();
+            users.add(generateUserInfo(email, password, nickname, Role.ROLE_USER));
+        }
+
+        List<Long> userIds = insertUsersInBulk(users);
+        insertBankAccounts(userIds, users.stream().map(UserInfo::nickname).toList());
+        insertDeliveryInfos(userIds);
+    }
+
+    private UserInfo generateUserInfo(String email, String password, String nickname, Role role) {
+        return new UserInfo(
+                email,
+                password,
+                nickname,
+                role.name(),
+                fakerKo.lorem().sentence(10),
+                fakerEn.internet().url()
+        );
+    }
+
+    private String generateEmail() {
+        return "user_" + UUID.randomUUID().toString().substring(0, 8) + "@example.com";
+    }
+
+    private String generateFakeAccountNumber() {
+        return String.format("%04d-%02d-%07d",
+                fakerKo.number().numberBetween(1000, 9999),
+                fakerKo.number().numberBetween(10, 99),
+                fakerKo.number().numberBetween(1000000, 9999999)
+        );
+    }
+
+    private List<Long> insertUsersInBulk(List<UserInfo> users) {
+        String sql = "INSERT INTO `user` (email, password, nickname, role, seller_introduction, link_url) VALUES (?, ?, ?, ?, ?, ?)";
+
+        jdbcTemplate.batchUpdate(sql, new BatchPreparedStatementSetter() {
+            @Override
+            public void setValues(PreparedStatement ps, int i) throws java.sql.SQLException {
+                UserInfo user = users.get(i);
+                ps.setString(1, user.email());
+                ps.setString(2, user.password());
+                ps.setString(3, user.nickname());
+                ps.setString(4, user.role());
+                ps.setString(5, user.introduction());
+                ps.setString(6, user.link());
+            }
+
+            @Override
+            public int getBatchSize() {
+                return users.size();
+            }
+        });
+
+        Long lastId = jdbcTemplate.queryForObject("SELECT MAX(id) FROM `user`", Long.class);
+        long startId = lastId - users.size() + 1;
+        List<Long> ids = new ArrayList<>();
+        for (int i = 0; i < users.size(); i++) {
+            ids.add(startId + i);
+        }
+        return ids;
+    }
+
+    private void insertBankAccounts(List<Long> userIds, List<String> nicknames) {
+        String sql = "INSERT INTO bank_account (user_id, account_number, account_holder, bank_name, is_default) VALUES (?, ?, ?, ?, ?)";
+
+        jdbcTemplate.batchUpdate(sql, new BatchPreparedStatementSetter() {
+            @Override
+            public void setValues(PreparedStatement ps, int i) throws java.sql.SQLException {
+                ps.setLong(1, userIds.get(i));
+                ps.setString(2, generateFakeAccountNumber());
+                ps.setString(3, nicknames.get(i));
+                ps.setString(4, "카카오뱅크");
+                ps.setBoolean(5, true);
+            }
+
+            @Override
+            public int getBatchSize() {
+                return userIds.size();
+            }
+        });
+    }
+
+    private void insertDeliveryInfos(List<Long> userIds) {
+        String sql = "INSERT INTO delivery_info (user_id, zipcode, address, detail_address, is_default) VALUES (?, ?, ?, ?, ?)";
+
+        jdbcTemplate.batchUpdate(sql, new BatchPreparedStatementSetter() {
+            @Override
+            public void setValues(PreparedStatement ps, int i) throws java.sql.SQLException {
+                ps.setLong(1, userIds.get(i));
+                ps.setString(2, fakerKo.numerify("###-###"));
+                ps.setString(3, fakerKo.address().cityName() + " " + fakerKo.address().streetName());
+                ps.setString(4, fakerKo.address().buildingNumber() + "호");
+                ps.setBoolean(5, true);
+            }
+
+            @Override
+            public int getBatchSize() {
+                return userIds.size();
+            }
+        });
+    }
+
+    private boolean checkAdminExists() {
+        String sql = "SELECT EXISTS (SELECT 1 FROM `user` WHERE role = ?)";
+        return Boolean.TRUE.equals(jdbcTemplate.queryForObject(sql, Boolean.class, Role.ROLE_ADMIN.name()));
+    }
+
+    private void insertPlatformPlansIfNotExists() {
+        if (!platformPlanRepository.existsByName(PlanName.BASIC)) {
+            platformPlanRepository.saveAll(List.of(
+                    PlatformPlan.builder()
+                            .name(PlanName.BASIC)
+                            .platformFeeRate(0.05)
+                            .pgFeeRate(0.03)
+                            .vatRate(0.10)
+                            .description("기본 요금제 - 최소 기능 제공")
+                            .build(),
+                    PlatformPlan.builder()
+                            .name(PlanName.PRO)
+                            .platformFeeRate(0.09)
+                            .pgFeeRate(0.03)
+                            .vatRate(0.10)
+                            .description("프로 요금제 - 마케팅 도구 포함")
+                            .build(),
+                    PlatformPlan.builder()
+                            .name(PlanName.PREMIUM)
+                            .platformFeeRate(0.15)
+                            .pgFeeRate(0.03)
+                            .vatRate(0.10)
+                            .description("프리미엄 요금제 - 전체 기능 제공 및 우선 지원")
+                            .build()
+            ));
+            System.out.println("✅ PlatformPlan 초기 데이터 삽입 완료");
+        }
+    }
+
+    private record UserInfo(
+            String email,
+            String password,
+            String nickname,
+            String role,
+            String introduction,
+            String link
+    ) {}
+}

--- a/athena/src/main/java/goorm/athena/domain/project/repository/PlatformPlanRepository.java
+++ b/athena/src/main/java/goorm/athena/domain/project/repository/PlatformPlanRepository.java
@@ -6,4 +6,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface PlatformPlanRepository extends JpaRepository<PlatformPlan, Long> {
     PlatformPlan findByName(PlanName name);
+    boolean existsByName(PlanName name);
 }

--- a/athena/src/main/java/goorm/athena/domain/user/entity/User.java
+++ b/athena/src/main/java/goorm/athena/domain/user/entity/User.java
@@ -71,4 +71,13 @@ public class User {
             this.nickname = nickname;
         }
     }
+
+    public static User createFullUser(String email, String password, String nickname,
+                                      Role role, String sellerIntroduction, String linkUrl) {
+        User user = new User(email, password, nickname);
+        user.role = role;
+        user.sellerIntroduction = sellerIntroduction;
+        user.linkUrl = linkUrl;
+        return user;
+    }
 }

--- a/athena/src/main/java/goorm/athena/domain/user/repository/UserRepository.java
+++ b/athena/src/main/java/goorm/athena/domain/user/repository/UserRepository.java
@@ -1,5 +1,6 @@
 package goorm.athena.domain.user.repository;
 
+import goorm.athena.domain.user.entity.Role;
 import goorm.athena.domain.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
@@ -7,5 +8,7 @@ public interface UserRepository extends JpaRepository<User, Long> {
     Boolean existsByEmail(String email);
 
     User findByEmail(String email);
+
+    boolean existsByRole(Role role);
 }
 

--- a/athena/src/main/java/goorm/athena/global/p6spy/P6SpyConfig.java
+++ b/athena/src/main/java/goorm/athena/global/p6spy/P6SpyConfig.java
@@ -1,0 +1,20 @@
+package goorm.athena.global.p6spy;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
+
+@Profile({"default", "test"})
+@Configuration
+public class P6SpyConfig {
+
+    @Bean
+    public P6SpyEventListener p6SpyCustomEventListener() {
+        return new P6SpyEventListener();
+    }
+
+    @Bean
+    public P6SpyFormatter p6SpyCustomFormatter() {
+        return new P6SpyFormatter();
+    }
+}

--- a/athena/src/main/java/goorm/athena/global/p6spy/P6SpyEventListener.java
+++ b/athena/src/main/java/goorm/athena/global/p6spy/P6SpyEventListener.java
@@ -1,0 +1,15 @@
+package goorm.athena.global.p6spy;
+
+import java.sql.SQLException;
+
+import com.p6spy.engine.common.ConnectionInformation;
+import com.p6spy.engine.event.JdbcEventListener;
+import com.p6spy.engine.spy.P6SpyOptions;
+
+public class P6SpyEventListener extends JdbcEventListener {
+
+    @Override
+    public void onAfterGetConnection(ConnectionInformation connectionInformation, SQLException e) {
+        P6SpyOptions.getActiveInstance().setLogMessageFormat(P6SpyFormatter.class.getName());
+    }
+}

--- a/athena/src/main/java/goorm/athena/global/p6spy/P6SpyFormatter.java
+++ b/athena/src/main/java/goorm/athena/global/p6spy/P6SpyFormatter.java
@@ -1,0 +1,78 @@
+package goorm.athena.global.p6spy;
+
+import java.util.Locale;
+
+import org.hibernate.engine.jdbc.internal.FormatStyle;
+
+import com.p6spy.engine.logging.Category;
+import com.p6spy.engine.spy.appender.MessageFormattingStrategy;
+
+public class P6SpyFormatter implements MessageFormattingStrategy {
+
+    private static final String NEW_LINE = "\n";
+    private static final String TAP = "\t";
+    private static final String CREATE = "create";
+    private static final String ALTER = "alter";
+    private static final String DROP = "drop";
+    private static final String COMMENT = "comment";
+
+    @Override
+    public String formatMessage(int connectionId, String now, long elapsed, String category, String prepared, String sql, String url) {
+        if (sql.trim().isEmpty()) {
+            return formatByCommand(category);
+        }
+        return formatBySql(sql, category) + getAdditionalMessages(elapsed);
+    }
+
+    private static String formatByCommand(String category) {
+        return NEW_LINE
+                + "Execute Command : "
+                + NEW_LINE
+                + NEW_LINE
+                + TAP
+                + category
+                + NEW_LINE
+                + NEW_LINE
+                + "----------------------------------------------------------------------------------------------------";
+    }
+
+    private String formatBySql(String sql, String category) {
+        if (isStatementDDL(sql, category)) {
+            return NEW_LINE
+                    + "Execute DDL : "
+                    + NEW_LINE
+                    + FormatStyle.DDL
+                    .getFormatter()
+                    .format(sql);
+        }
+        return NEW_LINE
+                + "Execute DML : "
+                + NEW_LINE
+                + FormatStyle.BASIC
+                .getFormatter()
+                .format(sql);
+    }
+
+    private String getAdditionalMessages(long elapsed) {
+        return NEW_LINE
+                + NEW_LINE
+                + String.format("Execution Time: %s ms", elapsed)
+                + NEW_LINE
+                + "----------------------------------------------------------------------------------------------------";
+    }
+
+    private boolean isStatementDDL(String sql, String category) {
+        return isStatement(category) && isDDL(sql.trim().toLowerCase(Locale.ROOT));
+    }
+
+    private boolean isStatement(String category) {
+        return Category.STATEMENT.getName().equals(category);
+    }
+
+    private boolean isDDL(String lowerSql) {
+        return lowerSql.startsWith(CREATE)
+                || lowerSql.startsWith(ALTER)
+                || lowerSql.startsWith(DROP)
+                || lowerSql.startsWith(COMMENT);
+    }
+}

--- a/athena/src/main/resources/application.yml
+++ b/athena/src/main/resources/application.yml
@@ -16,10 +16,13 @@ spring:
   jpa:
     hibernate:
       ddl-auto: update
-    show-sql: true
     properties:
       hibernate:
-        format_sql: true
+        jdbc:
+          default_batch_fetch_size: 100
+        order_inserts: true
+        order_updates: true
+
 
   kakao:
     api:
@@ -43,8 +46,16 @@ cloud:
       static: ap-northeast-2
     stack:
       auto: false
+logging:
+  level:
+    p6spy: info
 
+decorator:
+  datasource:
+    p6spy:
+      enable-logging: true
 jwt:
   secretKey: ${JWT_SECRET_KEY}
   refreshKey: ${JWT_REFRESH_KEY}
+
 


### PR DESCRIPTION
## Summary

>- close #103 
요금제 플랜과 유저와 계좌 배송지를 한번의 요청으로 생성하는 api를 구현했습니다  
쿼리를 효과적으로 추적하기 위해 커스텀 p6spy 를 도입했습니다 

## Tasks
- 스웨거 api 추가 
- 쿼리 출력 p6spy 추가 

## To Reviewer



## Screenshot
<img width="718" alt="스크린샷 2025-05-23 오후 7 55 14" src="https://github.com/user-attachments/assets/4eaead56-e624-44a4-b11c-e020a07394ec" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added an API endpoint to generate dummy user data, including associated accounts and delivery addresses, for development and testing purposes.
  - Introduced enhanced SQL query logging with custom formatting for improved database query visibility.
- **Improvements**
  - Optimized database batching and ordering for better performance during bulk operations.
- **Chores**
  - Updated application dependencies and configuration to support new features and logging enhancements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->