### PR TITLE
[#108] 쿠폰 더미데이터 생성 api 추가

### DIFF
--- a/athena/src/main/java/goorm/athena/domain/coupon/dto/req/CouponCreateRequest.java
+++ b/athena/src/main/java/goorm/athena/domain/coupon/dto/req/CouponCreateRequest.java
@@ -10,5 +10,16 @@ public record CouponCreateRequest(
         LocalDateTime endAt,
         LocalDateTime expiresAt,
         int stock
-) {
+)  {
+    public static CouponCreateRequest of(
+            String title,
+            String content,
+            int price,
+            LocalDateTime startAt,
+            LocalDateTime endAt,
+            LocalDateTime expiresAt,
+            int stock
+    ) {
+        return new CouponCreateRequest(title, content, price, startAt, endAt, expiresAt, stock);
+    }
 }

--- a/athena/src/main/java/goorm/athena/domain/coupon/entity/Coupon.java
+++ b/athena/src/main/java/goorm/athena/domain/coupon/entity/Coupon.java
@@ -65,4 +65,5 @@ public class Coupon {
     public void expired(){
         this.couponStatus = CouponStatus.ENDED;
     }
+
 }

--- a/athena/src/main/java/goorm/athena/domain/dummy/controller/DummyController.java
+++ b/athena/src/main/java/goorm/athena/domain/dummy/controller/DummyController.java
@@ -12,4 +12,8 @@ public interface DummyController {
     @Operation(summary = "더미 유저 생성", description = "입력된 숫자만큼 유저/계좌/배송지 더미 데이터를 생성합니다.")
     @PostMapping("/api/dev/dummy-users")
     ResponseEntity<String> createDummyUsers(@RequestParam(defaultValue = "10") int count);
+
+    @Operation(summary = "더미 쿠폰 생성", description = "입력된 숫자만큼 쿠폰 더미 데이터를 생성합니다.")
+    @PostMapping("/api/dev/dummy-coupons")
+    ResponseEntity<String> generateCoupons(@RequestParam(defaultValue = "10") int count);
 }

--- a/athena/src/main/java/goorm/athena/domain/dummy/controller/DummyControllerImpl.java
+++ b/athena/src/main/java/goorm/athena/domain/dummy/controller/DummyControllerImpl.java
@@ -1,6 +1,7 @@
 package goorm.athena.domain.dummy.controller;
 
-import goorm.athena.domain.dummy.service.DummyService;
+import goorm.athena.domain.dummy.service.DummyCouponService;
+import goorm.athena.domain.dummy.service.DummyUserService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -13,11 +14,19 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/api/dev")
 public class DummyControllerImpl implements DummyController {
 
-    private final DummyService dummyDataService;
+    private final DummyUserService dummyUserService;
+    private final DummyCouponService dummyCouponService;
+
 
     @PostMapping("/dummy-users")
     public ResponseEntity<String> createDummyUsers(@RequestParam(defaultValue = "10") int count) {
-        dummyDataService.generateDummyUsers(count);
+        dummyUserService.generateDummyUsers(count);
         return ResponseEntity.ok(count + "개의 더미 유저가 생성되었습니다.");
+    }
+
+    @PostMapping("/dummy-coupons")
+    public ResponseEntity<String> generateCoupons(@RequestParam(defaultValue = "10") int count) {
+        dummyCouponService.generateDummyCoupons(count);
+        return ResponseEntity.ok(count + "개의 더미 쿠폰이 생성되었습니다.");
     }
 }

--- a/athena/src/main/java/goorm/athena/domain/dummy/dto/UserInfo.java
+++ b/athena/src/main/java/goorm/athena/domain/dummy/dto/UserInfo.java
@@ -1,0 +1,10 @@
+package goorm.athena.domain.dummy.dto;
+
+public record UserInfo(
+        String email,
+        String password,
+        String nickname,
+        String role,
+        String introduction,
+        String link
+) {}

--- a/athena/src/main/java/goorm/athena/domain/dummy/service/DummyCouponService.java
+++ b/athena/src/main/java/goorm/athena/domain/dummy/service/DummyCouponService.java
@@ -1,0 +1,119 @@
+package goorm.athena.domain.dummy.service;
+
+import goorm.athena.domain.coupon.dto.req.CouponCreateRequest;
+import goorm.athena.domain.coupon.entity.Coupon;
+import goorm.athena.domain.coupon.entity.CouponStatus;
+import goorm.athena.domain.coupon.repository.CouponRepository;
+import goorm.athena.global.exception.CustomException;
+import goorm.athena.global.exception.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import net.datafaker.Faker;
+import org.springframework.jdbc.core.BatchPreparedStatementSetter;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.sql.PreparedStatement;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+import java.util.Random;
+
+@Service
+@RequiredArgsConstructor
+public class DummyCouponService {
+
+    private final JdbcTemplate jdbcTemplate;
+    private final Faker faker = new Faker(new Locale("ko"));
+    private final Random random = new Random();
+
+    private static final int[] STOCK_CHOICES = {100, 200, 300, 400, 500};
+
+    @Transactional
+    public void generateDummyCoupons(int count) {
+        List<Object[]> jdbcValues = new ArrayList<>();
+        LocalDateTime now = LocalDateTime.now();
+
+        for (int i = 0; i < count; i++) {
+            CouponStatus status = getRandomStatus();
+            LocalDateTime startAt, endAt;
+
+            // 상태별 기간 설정
+            switch (status) {
+                case PREVIOUS -> {
+                    startAt = now.plusDays(random.nextInt(10) + 1);
+                    endAt = startAt.plusDays(random.nextInt(10) + 1);
+                }
+                case IN_PROGRESS -> {
+                    startAt = now;
+                    endAt = now.plusDays(random.nextInt(10) + 1);
+                }
+                case ENDED -> {
+                    long daysAgo = 365 + random.nextInt(365);
+                    startAt = now.minusDays(daysAgo);
+                    endAt = startAt.plusDays(random.nextInt(10) + 1);
+                }
+                default -> throw new CustomException(ErrorCode.INVALID_COUPON_STATUS);
+            }
+
+            LocalDateTime expiresAt = endAt.plusDays(30);
+            int price = (random.nextInt(10) + 1) * 1000;
+
+            int stock = STOCK_CHOICES[random.nextInt(STOCK_CHOICES.length)];
+
+            // 💡 할인 쿠폰 주제 기반 타이틀/내용
+            String discountType = switch (random.nextInt(5)) {
+                case 0 -> "첫 구매";
+                case 1 -> "앱 전용";
+                case 2 -> "주말 한정";
+                case 3 -> "생일 축하";
+                default -> "단골 고객";
+            };
+
+            String title = discountType + " " + price + "원 할인 쿠폰";
+            String content = String.format(
+                    "%s에서 사용 가능한 %,d원 할인 쿠폰입니다. %s 고객님을 위한 혜택이에요!",
+                    faker.company().name(), price, discountType
+            );
+
+            jdbcValues.add(new Object[]{
+                    title, content, price, startAt, endAt, expiresAt, stock, status.name()
+            });
+        }
+
+        String sql = """
+            INSERT INTO coupon (title, content, price, start_at, end_at, expires_at, stock, coupon_status)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+        """;
+
+        jdbcTemplate.batchUpdate(sql, new BatchPreparedStatementSetter() {
+            @Override
+            public void setValues(PreparedStatement ps, int i) throws java.sql.SQLException {
+                Object[] row = jdbcValues.get(i);
+                ps.setString(1, (String) row[0]);
+                ps.setString(2, (String) row[1]);
+                ps.setInt(3, (int) row[2]);
+                ps.setObject(4, row[3]);
+                ps.setObject(5, row[4]);
+                ps.setObject(6, row[5]);
+                ps.setInt(7, (int) row[6]);
+                ps.setString(8, (String) row[7]);
+            }
+
+            @Override
+            public int getBatchSize() {
+                return jdbcValues.size();
+            }
+        });
+
+        System.out.println("더미 쿠폰 " + count + "개 생성 완료");
+    }
+
+    private CouponStatus getRandomStatus() {
+        int roll = random.nextInt(100);
+        if (roll < 20) return CouponStatus.PREVIOUS;
+        if (roll < 30) return CouponStatus.IN_PROGRESS;
+        return CouponStatus.ENDED;
+    }
+}


### PR DESCRIPTION
## Summary

>- close #108 

쿠폰 더미데이터를 생성하는 api를 추가했습니다 
JDBC 기반의 batch insert를 사용하여 성능을 고려했으며, 쿠폰 상태(PREVIOUS, IN_PROGRESS, ENDED)에 따라 기간을 다르게 생성하고, 쿠폰 이름과 설명도 실제 할인 쿠폰과 유사하게 생성되도록 개선했습니다.

## Tasks
- 스웨거 api 추가 
## To Reviewer
stock은 100~500까지 100단위로 랜덤 설정
요청 수에 따라서 아래 비율로 생성됩니다 
PREVIOUS20%
IN_PROGRESS10%
ENDED70%
로 생성됩니다 


DB에 저장된 쿠폰이 할인 쿠폰처럼 보이는지 (제목, 설명, 상태, 기간 등) 확인 부탁드립니다.
## Screenshot

