### PR TITLE
[#185] 쿠폰 레디스 개선

### DIFF
--- a/athena/src/main/java/goorm/athena/domain/bankaccount/mapper/BankAccountMapper.java
+++ b/athena/src/main/java/goorm/athena/domain/bankaccount/mapper/BankAccountMapper.java
@@ -16,5 +16,6 @@ public interface BankAccountMapper {
     BankAccount toEntity(User user, BankAccountCreateRequest request, Boolean isDefault);
 
     @Mapping(target = "bankAccount", source = "accountNumber")
+    @Mapping(target = "isDefault", source = "default")
     BankAccountGetResponse toGetResponse(BankAccount bankAccount);
 }

--- a/athena/src/main/java/goorm/athena/domain/coupon/mapper/CouponMapper.java
+++ b/athena/src/main/java/goorm/athena/domain/coupon/mapper/CouponMapper.java
@@ -11,8 +11,10 @@ import org.mapstruct.Mapping;
 @Mapper(componentModel = "spring")
 public interface CouponMapper {
 
+    @Mapping(target = "status", source = "couponStatus")
     CouponCreateResponse toCreateResponse(Coupon coupon);
 
+    @Mapping(target = "status", source = "couponStatus")
     CouponGetResponse toGetResponse(Coupon coupon);
 
     @Mapping(target = "status", source = "couponStatus")

--- a/athena/src/main/java/goorm/athena/domain/coupon/scheduler/CouponScheduler.java
+++ b/athena/src/main/java/goorm/athena/domain/coupon/scheduler/CouponScheduler.java
@@ -52,6 +52,8 @@ public class CouponScheduler {
                  couponMeta.put("used", "0");
                  couponMeta.put("sync_triggered", "0");
 
+                 // total, used : 이전 버전들을 위한 Redis 키 ( v4_8은 해시 키로 통합 관리하여 미사용 )
+                 // issued_users : 어느 유저가 쿠폰을 발급했는지 확인하기 위한 Redis key
                  redissonClient.getAtomicLong("coupon_total_" + coupon.getId()).set(coupon.getStock()); // DB 기준
                  redissonClient.getAtomicLong("coupon_used_" + coupon.getId()).set(0L);
                  redissonClient.getSet("issued_users_" + coupon.getId()).clear();

--- a/athena/src/main/java/goorm/athena/domain/deliveryinfo/mapper/DeliveryInfoMapper.java
+++ b/athena/src/main/java/goorm/athena/domain/deliveryinfo/mapper/DeliveryInfoMapper.java
@@ -18,5 +18,8 @@ public interface DeliveryInfoMapper {
     @Mapping(target = "detailAddress", source = "request.detailAddress")
     DeliveryInfo toEntity(User user, DeliveryInfoRequest request, boolean isDefault);
 
+    @Mapping(target = "isDefault", source = "default")
+    DeliveryInfoResponse toGetResponse(DeliveryInfo deliveryInfo);
+
     List<DeliveryInfoResponse> toGetResponse(List<DeliveryInfo> deliveryInfo);
 }

--- a/athena/src/main/java/goorm/athena/domain/userCoupon/infra/RedisKeyExpirationListener.java
+++ b/athena/src/main/java/goorm/athena/domain/userCoupon/infra/RedisKeyExpirationListener.java
@@ -1,0 +1,50 @@
+    package goorm.athena.domain.userCoupon.infra;
+
+    import goorm.athena.domain.coupon.event.CouponSyncTriggerEvent;
+    import lombok.RequiredArgsConstructor;
+    import lombok.extern.slf4j.Slf4j;
+    import org.redisson.api.RMap;
+    import org.redisson.api.RedissonClient;
+    import org.redisson.client.codec.StringCodec;
+    import org.springframework.context.ApplicationEventPublisher;
+    import org.springframework.stereotype.Component;
+
+    import javax.annotation.PostConstruct;
+
+    @Slf4j
+    @Component
+    @RequiredArgsConstructor
+    public class RedisKeyExpirationListener {
+
+        private final RedissonClient redissonClient;
+        private final ApplicationEventPublisher publisher;
+
+        @PostConstruct
+        public void registerExpirationListener() {
+            // Redis 키 TTL 만료 이벤트 구독 ( DB 0 기준 )
+            redissonClient.getTopic("__keyevent@0__:expired", StringCodec.INSTANCE)
+                    .addListener(String.class, (channel, expiredKey) -> {
+                        log.info("Redis TTL 만료 감지: {}", expiredKey);
+
+                        if (expiredKey.startsWith("coupon_ttl_")) {
+                            try {
+                                Long couponId = Long.parseLong(expiredKey.replace("coupon_ttl_", ""));
+
+                                String metaKey = "coupon_meta_" + couponId;
+                                RMap<String, String> couponMeta = redissonClient.getMap(metaKey, StringCodec.INSTANCE);
+
+                                String syncTriggered = couponMeta.getOrDefault("sync_triggered", "0");
+                                if ("1".equals(syncTriggered)) {
+                                    log.info("이미 동기화된 쿠폰입니다. 이벤트 발행하지 않음: couponId={}", couponId);
+                                    return;
+                                }
+
+                                log.info("TTL 만료로 쿠폰 동기화 이벤트 발행: couponId={}", couponId);
+                                publisher.publishEvent(new CouponSyncTriggerEvent(couponId));
+                            } catch (Exception e) {
+                                log.error("쿠폰 ID 파싱 실패: {}", expiredKey, e);
+                            }
+                        }
+                    });
+        }
+    }

--- a/athena/src/main/java/goorm/athena/domain/userCoupon/mapper/UserCouponMapper.java
+++ b/athena/src/main/java/goorm/athena/domain/userCoupon/mapper/UserCouponMapper.java
@@ -24,6 +24,7 @@ public interface UserCouponMapper {
     @Mapping(target = "price", source = "userCoupon.coupon.price")
     @Mapping(target = "stock", source = "userCoupon.coupon.stock")
     @Mapping(target = "expires", source = "userCoupon.coupon.expiresAt")
+    @Mapping(target = "couponId", source = "userCoupon.coupon.id")
     UserCouponGetResponse toGetResponse(UserCoupon userCoupon);
 
     UserCouponCursorResponse toGetCursorResponse(List<UserCouponGetResponse> content, Long nextCouponId, Long total);

--- a/infra/docker/docker-compose.yml
+++ b/infra/docker/docker-compose.yml
@@ -37,6 +37,8 @@ services:
     command:
       - redis-server
       - --requirepass ${REDIS_PASSWORD}
+      - --notify-keyspace-events
+      - Ex
 
   athena:
     build: ../../athena


### PR DESCRIPTION
## Summary

>- close #185 

- LuaScript를 캐싱하도록 변경
- 쿠폰 발급에 TTL을 위한 키를 추가하여 재고 동기 개선
- Mapper에 속성을 명시하여 WARNING 삭제

## Tasks

- LuaScript를 캐싱 및 재사용하여 캐싱 시간을 절약했습니다.
- 쿠폰 발급에 재고 동기를 위한 TTL키 (빠른 재고 확인을 위해 10초)를 추가했습니다.
- Mapper에 속성을 명시하여 서버 진행에서 WARNING이 뜨는 문제를 해결했습니다.

## To Reviewer
### 쿠폰 발급에 재고 동기를 위해 TTL 키를 추가했습니다.
- TTL 키는 빠른 재고 동기 확인을 위해 10초로 설정하였습니다.
- 유저가 쿠폰 발급을 진행했다면 TTL 키가 발급되며, TTL키가 만료되면 남은 재고를 DB에 동기합니다.
- 정상적 TTL 진행을 위해선, Docker의 Redis 설정에 TTL 설정만 해주면 됩니다.